### PR TITLE
remove unnecessary wrapping around Angular signal getters

### DIFF
--- a/src/frameworks/angularSignals.ts
+++ b/src/frameworks/angularSignals.ts
@@ -7,13 +7,13 @@ export const angularFramework: ReactiveFramework = {
     const s = signal(initialValue);
     return {
       write: (v) => s.set(v),
-      read: () => s(),
+      read: s,
     };
   },
   computed: (fn) => {
     const c = computed(fn);
     return {
-      read: () => c(),
+      read: c,
     };
   },
   effect,


### PR DESCRIPTION
The wrapping functions around Angular signal getters are not needed and my be causing 10-20% slowdown on selected benchmarks.